### PR TITLE
Makes code independent of D2O

### DIFF
--- a/galmag/B_field.py
+++ b/galmag/B_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/B_field.py
+++ b/galmag/B_field.py
@@ -238,14 +238,11 @@ class B_field_component(object):
         """
         internal_field = getattr(self, "_"+name)
 
-        if data is None:
-            internal_field = None
+        if (data is None) or (not copy):
+            setattr(self, "_"+name, data)
         else:
-            if internal_field is None:
-                setattr(self, '_'+name,
-                        self.grid.get_prototype(dtype=self.dtype))
-                internal_field = getattr(self, "_"+name)
-            internal_field.set_full_data(data, copy=copy)
+            setattr(self, "_"+name, data.copy())
+
 
 
 class B_field(object):

--- a/galmag/B_generators/B_generator.py
+++ b/galmag/B_generators/B_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/B_generators/B_generator_disk.py
+++ b/galmag/B_generators/B_generator_disk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/B_generators/B_generator_halo.py
+++ b/galmag/B_generators/B_generator_halo.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/Grid.py
+++ b/galmag/Grid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #
@@ -20,7 +20,6 @@
 Contains the definition of the Grid class.
 """
 import numpy as np
-from d2o import distributed_data_object
 
 
 class Grid(object):

--- a/galmag/Grid.py
+++ b/galmag/Grid.py
@@ -118,7 +118,7 @@ class Grid(object):
     def _generate_coordinates(self):
         # Initializes all coordinate arrays
         [x_array, y_array, z_array, r_spherical_array, r_cylindrical_array,
-         theta_array, phi_array] = [np.empty(self.resolution) for i in range(7)]
+         theta_array, phi_array] = [self.get_prototype() for i in range(7)]
 
         # The definitions of "local_coordinates" may help if a distributed
         # version is wanted in the future. Version 1.1.0 of GalMag may be used
@@ -205,3 +205,5 @@ class Grid(object):
 
         return result_dict
 
+    def get_prototype(self, dtype=None):
+        return np.empty(self.resolution, dtype=dtype)

--- a/galmag/Observables.py
+++ b/galmag/Observables.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/__init__.py
+++ b/galmag/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # GalMag - A Python tool for computing realistic galactic magnetic fields
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # GalMag is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/galmag/disk_profiles.py
+++ b/galmag/disk_profiles.py
@@ -20,7 +20,6 @@ Contains the definitions of the disk rotation curve, radial shear,
 alpha profile and disk scale height.
 """
 import numpy as np
-from galmag.util import distribute_function
 
 def solid_body_rotation_curve(R, R_d=1.0, Rsun=8.5, V0=220, normalize=True):
     """

--- a/galmag/electron_profiles.py
+++ b/galmag/electron_profiles.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/galerkin.py
+++ b/galmag/galerkin.py
@@ -24,6 +24,7 @@ import numpy as np
 import galmag.halo_free_decay_modes as halo_free_decay_modes
 from .Grid import Grid
 from .util import curl_spherical, simpson
+#from numba import njit, jit
 
 def Galerkin_expansion_coefficients(parameters, return_matrix=False,
                                     dtype=np.float64):
@@ -175,7 +176,7 @@ def Galerkin_expansion_coefficients(parameters, return_matrix=False,
         return val, vec, Wij
 
 
-
+#@jit
 def perturbation_operator(r, theta, phi, Br, Bt, Bp, Vr, Vt, Vp,
                           alpha, Ra, Ro, dynamo_type='alpha-omega'):
     r"""
@@ -221,6 +222,3 @@ def perturbation_operator(r, theta, phi, Br, Bt, Bp, Vr, Vt, Vp,
             raise AssertionError('Invalid option: dynamo_type={0}'.format(dynamo_type))
 
     return WBs
-
-
-

--- a/galmag/halo_free_decay_modes.py
+++ b/galmag/halo_free_decay_modes.py
@@ -22,15 +22,15 @@ of the halo of a galaxy.
 They should be accessed through the function :func:`get_mode`.
 """
 from scipy.special import j0, j1, jv, jn_zeros
-import numpy as N
+import numpy as np
 from sympy import besselj
 from mpmath import mp, findroot
 import os.path
-pi=N.pi
-cos = N.cos
-tan = N.tan
-sin = N.sin
-sqrt = N.sqrt
+pi=np.pi
+cos = np.cos
+tan = np.tan
+sin = np.sin
+sqrt = np.sqrt
 
 def get_B_a_1(r, theta, phi, C=0.346, k=pi):
     r"""
@@ -57,7 +57,7 @@ def get_B_a_1(r, theta, phi, C=0.346, k=pi):
         :math:`B_r`, :math:`B_\theta`, :math:`B_\phi`
     """
     # Computes radial component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     separator = r <=1
     Q[separator] = r[separator]**(-0.5)*jv(3.0/2.0,k*r[separator])
     Q[~separator] = r[~separator]**(-2.0)*jv(3.0/2.0,k)
@@ -66,7 +66,7 @@ def get_B_a_1(r, theta, phi, C=0.346, k=pi):
 
     # Computes polar component
     # X = d(rQ1)/dr
-    X = N.empty_like(r)
+    X = np.empty_like(r)
     y = k*r[separator]
     X[separator] = sqrt(2.0/pi)*(y**2*sin(y) - sin(y) +
                                  y*cos(y)) / (k**(-0.5)*y**2)
@@ -75,7 +75,7 @@ def get_B_a_1(r, theta, phi, C=0.346, k=pi):
     Btheta = C*(-sin(theta)/r)*X
 
     # Sets azimuthal component
-    Bphi   = N.zeros_like(r)
+    Bphi   = np.zeros_like(r)
 
     return Br, Btheta, Bphi
 
@@ -107,7 +107,7 @@ def get_B_a_2(r, theta, phi, C=0.250, k=5.763):
 
     # Computes radial component
     separator = r <=1.
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(7.0/2.0, k*r[separator])
     Q[~separator] = r[~separator]**(-4.0)*jv(7.0/2.0, k)
 
@@ -117,7 +117,7 @@ def get_B_a_2(r, theta, phi, C=0.250, k=5.763):
     # X = d(rQ1)/dr
     # r<=1, first define some auxiliary quantities
     y = k*r[separator]
-    X = N.empty_like(r)
+    X = np.empty_like(r)
 
     X[separator]  = k**(0.5)*y**(0.5)*(jv(2.5,y) - jv(4.5,y))/2.0 \
                     + 0.5*r[separator]**(-0.5)*jv(3.5,y)
@@ -128,7 +128,7 @@ def get_B_a_2(r, theta, phi, C=0.250, k=5.763):
     Btheta = C*(-sin(theta)/r)*(5.*(cos(theta))**2-1.)*X
 
     # Sets azimuthal component
-    Bphi   = N.zeros_like(r)
+    Bphi   = np.zeros_like(r)
 
     return Br, Btheta, Bphi
 
@@ -161,13 +161,13 @@ def get_B_a_3(r, theta, phi, C=3.445, k=5.763):
     separator = r <=1.
 
     # Sets radial component
-    Br = N.zeros_like(r)
+    Br = np.zeros_like(r)
 
     # Sets polar component
-    Btheta = N.zeros_like(r)
+    Btheta = np.zeros_like(r)
 
     # Computes azimuthal component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(5.0/2.0, k*r[separator])
     Q[~separator] = r[~separator]**(-3.0)*jv(5.0/2.0, k)
 
@@ -231,14 +231,14 @@ def get_B_s_1(r, theta, phi, C=0.653646562698, k=4.493409457909):
     separator = r <=1.
 
     # Computes radial component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(5.0/2.0,k*r[separator])
     Q[~separator]  = r[~separator]**(-3.0)*jv(5.0/2.0,k)
 
     Br = C*Q*(3.0*cos(theta)**2-1)/r
 
     # Computes theta component
-    X = N.zeros_like(r)
+    X = np.zeros_like(r)
     y = k*r[separator]
     siny = sin(y)
     cosy = cos(y)
@@ -251,7 +251,7 @@ def get_B_s_1(r, theta, phi, C=0.653646562698, k=4.493409457909):
     Btheta = C*(-sin(theta)*cos(theta)/r)*X
 
     # Sets azimuthal component
-    Bphi   = N.zeros_like(r)
+    Bphi   = np.zeros_like(r)
 
     return Br, Btheta, Bphi
 
@@ -284,13 +284,13 @@ def get_B_s_2(r, theta, phi, C=1.32984358196, k=4.493409457909):
     separator = r <=1.
 
     # Sets radial component
-    Br = N.zeros_like(r)
+    Br = np.zeros_like(r)
 
     # Sets theta component
-    Btheta = N.zeros_like(r)
+    Btheta = np.zeros_like(r)
 
     # Computes azimuthal component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(3.0/2.0, k*r[separator])
     Q[~separator] = r[~separator]**(-2.0)*jv(3.0/2.0, k)
 
@@ -330,7 +330,7 @@ def get_B_s_3(r, theta, phi, C=0.0169610298034, k=6.987932000501):
     y = k*r[separator]
 
     # Computes radial component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(9.0/2.0,y)
     Q[~separator]  = r[~separator]**(-5.0)*jv(9.0/2.0,k)
     S = -700.*cost**4+600.*cost**2-60
@@ -346,7 +346,7 @@ def get_B_s_3(r, theta, phi, C=0.0169610298034, k=6.987932000501):
     Btheta = -C * Q * S/r
 
     # Sets azimuthal component
-    Bphi = N.zeros_like(r)
+    Bphi = np.zeros_like(r)
 
     return Br, Btheta, Bphi
 
@@ -378,13 +378,13 @@ def get_B_s_4(r, theta, phi, C=0.539789362061, k=6.987932000501):
     separator = r <=1.
 
     # Sets radial component
-    Br = N.zeros_like(r)
+    Br = np.zeros_like(r)
 
     # Sets theta component
-    Btheta = N.zeros_like(r)
+    Btheta = np.zeros_like(r)
 
     # Computes azimuthal component
-    Q = N.empty_like(r)
+    Q = np.empty_like(r)
     Q[separator] = r[separator]**(-0.5)*jv(7.0/2.0, k*r[separator])
     Q[~separator] = r[~separator]**(-4.0)*jv(7.0/2.0, k)
     S = 3.*sin(theta)*(1.-5.*(cos(theta))**2)
@@ -481,8 +481,8 @@ class xi_lookup_table(object):
         if regenerate or (not os.path.isfile(filepath)):
             self.generate_xi_lookup_table(**kwargs)
         else:
-            self.table = N.load(filepath)
-            self.max_n, self.max_l = N.shape(self.table)
+            self.table = np.load(filepath)
+            self.max_n, self.max_l = np.shape(self.table)
 
 
     def get_xi(self, n, l, regenerate=False, **kwargs):
@@ -539,7 +539,7 @@ class xi_lookup_table(object):
 
         .. math::
             \gamma_{nl} = -(\xi_{nl})^2
-        
+
         The root are found using the mpmath.findroot function. The search
         for roots supplying findroot with number_of_guesses initial guesses
         uniformly distributed in the interval [3,max_guess].
@@ -560,7 +560,7 @@ class xi_lookup_table(object):
         numpy.ndarray
             A (max_n,max_l)-array containing containing the roots of
         """
-        self.table = N.empty((max_n,max_l))
+        self.table = np.empty((max_n,max_l))
         guesses = linspace(3,max_guess,number_of_guesses)
 
         for n in range(1,max_n+1):
@@ -571,16 +571,16 @@ class xi_lookup_table(object):
                 try:
 
                     # Stores every root found
-                    results.append(N.float64(findroot(f, guess)))
+                    results.append(np.float64(findroot(f, guess)))
                 except ValueError:
                     # Ignores failures in finding the root
                     pass
             # Excludes identical results
-            results = N.unique(results)
+            results = np.unique(results)
             # Avoids spurious results close to 0
             results = results[results>1.0]
             # Updates table
             self.table[n-1,:] = results[:max_l]
         if save:
-            N.save(self.filepath, self.table)
-        self.max_n, self.max_l = N.shape(self.table)
+            np.save(self.filepath, self.table)
+        self.max_n, self.max_l = np.shape(self.table)

--- a/galmag/halo_free_decay_modes.py
+++ b/galmag/halo_free_decay_modes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #

--- a/galmag/halo_profiles.py
+++ b/galmag/halo_profiles.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017,2018,2019 Luiz Felippe S. Rodrigues <luiz.rodrigues@ncl.ac.uk>
+# Copyright (C) 2017,2018,2019,2020 Luiz Felippe S. Rodrigues <luizfelippesr@alumni.usp.br>
 #
 # This file is part of GalMag.
 #
@@ -59,7 +59,6 @@ def simple_V(rho, theta, phi, r_h=1.0, Vh=220, fraction=3./15., normalize=True,
         :math:`V_r`, :math:`V_\theta`, :math:`V_\phi`
     """
     Vr, Vt = [np.zeros_like(rho) for i in range(2)]
-
 
     Vp = (1.0-np.exp(-np.abs(rho*np.sin(theta))/(fraction*r_h)))
     if not legacy:
@@ -185,9 +184,7 @@ def simple_alpha(rho, theta, phi, alpha0=1.0):
         Azimuthal coordinate, :math:`\phi`
     alpha0 : float, optional
         Normalization. Default: 1.0
-
     """
-
     alpha = np.cos(theta)
     alpha[rho>1.] = 0.
 

--- a/galmag/util.py
+++ b/galmag/util.py
@@ -21,7 +21,7 @@ Auxiliary functions.
 import numpy as np
 from numba import jit, njit
 
-@njit
+@njit(parallel=True)
 def derive(V, dx, axis=0, order=2):
     """
     Computes the numerical derivative of a function specified over a
@@ -108,7 +108,8 @@ def derive(V, dx, axis=0, order=2):
 
     return dVdx
 
-@njit
+
+@njit(parallel=True)
 def curl_spherical(rr, tt, pp, Br, Bt, Bp, order=2):
     r"""
     Computes the curl of a vector in spherical coordinates.
@@ -175,7 +176,8 @@ def curl_spherical(rr, tt, pp, Br, Bt, Bp, order=2):
 
     return cBr, cBtheta, cBphi
 
-@njit
+
+@njit(parallel=True)
 def simpson(f, r):
     """Integrates over the last axis"""
     shape_r = r.shape

--- a/galmag/util.py
+++ b/galmag/util.py
@@ -19,9 +19,9 @@
 Auxiliary functions.
 """
 import numpy as np
-from numba import jit, njit
+#from numba import jit, njit
 
-@njit(parallel=True)
+#@njit
 def derive(V, dx, axis=0, order=2):
     """
     Computes the numerical derivative of a function specified over a
@@ -180,7 +180,7 @@ def curl_spherical(rr, tt, pp, Br, Bt, Bp, order=2):
     return cBr, cBtheta, cBphi
 
 
-@njit(parallel=True)
+#@jit
 def simpson(f, r):
     """Integrates over the last axis"""
     shape_r = r.shape

--- a/galmag/util.py
+++ b/galmag/util.py
@@ -46,10 +46,7 @@ def derive(V, dx, axis=0, order=2):
         The derivative, dV/dx
 
     """
-    if isinstance(V, distributed_data_object):
-        dVdx = V.copy_empty()
-    else:
-        dVdx = np.empty_like(V)
+    dVdx = np.empty_like(V)
 
     if axis==0:
         if order==2:
@@ -157,13 +154,13 @@ def curl_spherical(rr, tt, pp, Br, Bt, Bp, order=2):
     dBphi_dtheta = derive(Bp, dtheta, axis=1, order=order)
 
     # Auxiliary
-    tant = distribute_function(np.tan, tt)
+    tant = np.tan(tt)
 
     if dphi:
         dBr_dphi = derive(Br, dphi, axis=2, order=order)
         dBtheta_dphi = derive(Bt, dphi, axis=2, order=order)
         dBphi_dphi = derive(Bp, dphi, axis=2, order=order)
-        sint = distribute_function(np.sin, tt)
+        sint = np.sin(tt)
 
     # Components of the curl
     cBr = dBphi_dtheta/rr + Bp/tant/rr

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # GalMag
-# Copyright (C) 2017  Luiz Felippe S. Rodrigues
+# Copyright (C) 2020  Luiz Felippe S. Rodrigues
 #
 # GalMag is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,7 +41,5 @@ setup(name="galmag",
       python_requires='>=3.5, <4',
       zip_safe=False,
       long_description=read('README.rst'),
-      dependency_links=[
-        'git+https://gitlab.mpcdf.mpg.de/ift/d2o.git#egg=d2o'],
       install_requires=requirements,
       )

--- a/test/test_free.py
+++ b/test/test_free.py
@@ -10,27 +10,25 @@ r""" Script that tests the free decay modes
 import galmag
 from galmag.util import curl_spherical
 from galmag import halo_free_decay_modes as free
-import numpy as N
+import numpy as np
 from galmag.Grid import Grid
 
-pi = N.pi
+pi = np.pi
 Nop=10
 for No in range(350,901,100):
-
-    print '\n\nChecking the free decay modes. Will compute '
-    print r'$x = - \nabla \times \nabla \times \bm{B} / \bm{B}/\gamma $'
-    print '\nGrid shape: N_r x N_\\theta x N_\\phi = {0}x{0}x{1}'.format(No,Nop)
-    print
+    print('\n\nChecking the free decay modes. Will compute ')
+    print(r'$x = - \nabla \times \nabla \times \bm{B} / \bm{B}/\gamma $')
+    print('\nGrid shape: N_r x N_\\theta x N_\\phi = {0}x{0}x{1}\n'.format(No,Nop))
 
     grid = Grid([[0.01,1.0], # r range
-                [0.000001,N.pi],  # theta range
-                [17e-5,2.*N.pi]], # phi range
+                [0.000001,np.pi],  # theta range
+                [17e-5,2.*np.pi]], # phi range
                 resolution=[No,No,Nop],
                 grid_type='spherical')
-      
-    rr = N.array(grid.r_spherical)
-    tt = N.array(grid.theta)
-    pp = N.array(grid.phi)
+
+    rr = np.array(grid.r_spherical)
+    tt = np.array(grid.theta)
+    pp = np.array(grid.phi)
     for symmetric in (True, False):
         for n_mode in range(1,5):
             if symmetric:
@@ -40,13 +38,11 @@ for No in range(350,901,100):
                 symmetry = 'a'
                 gamma = free.gamma_a[n_mode-1]
 
-            print r'B_{0}_{1}'.format(symmetry,n_mode)
-            print '\t', '     ', 'mean(x)      ', ' std(x)'
+            print(r'B_{0}_{1}'.format(symmetry,n_mode), flush=True)
+            print('\t', '     ', 'mean(x)      ', ' std(x)')
 
             B = free.get_mode(rr, tt, pp, n_mode, symmetric)
-
             curl_B = curl_spherical(rr, tt, pp, B[0], B[1], B[2], order=2)
-
             curl_curl_B = curl_spherical(rr,
                                          tt,
                                          pp,
@@ -58,10 +54,11 @@ for No in range(350,901,100):
                     for i in range(3)]
 
             for i, name in zip([0,1,2],['r    ','theta','phi  ']):
-                if N.all(B[i]==B[i]*0.0):
+                if np.all(B[i]==B[i]*0.0):
                     # If the magnetic field is 0, there is nothing to compare.
-                    print '\t', name, 'zero'
+                    print('\t', name, 'zero')
                 else:
                     #
-                    print '\t', name, gamma_computed[i][3:-3,3:-3,3].mean()/gamma,
-                    print (gamma_computed[i][3:-3,3:-3,3]/gamma).std()
+                    mean = gamma_computed[i][3:-3,3:-3,3].mean()/gamma
+                    std = (gamma_computed[i][3:-3,3:-3,3]/gamma).std()
+                    print('\t{0:s} {1:1.4f} {2:1.4f}'.format(name, mean, std))


### PR DESCRIPTION
While D2O is a very interesting concept, the typical use-case of GalMag does not involve very large models which require MPI parallelisation.  Ideally, instead o MPI paralleisation, one would prefer a shared memory multi-processing paradigm (e.g. OpenMP), which would automatically scale to use resources available in laptops or single computing nodes in clusters.

Thus, to make the code dependencies simpler and to allow easier integration with IMAGINE, this pull request removes the reliance on D2O, converting any distributed data objects to simple numpy arrays. 